### PR TITLE
Fixing da-teacher sample.json

### DIFF
--- a/samples/da-teacher/assets/sample.json
+++ b/samples/da-teacher/assets/sample.json
@@ -2,15 +2,15 @@
     {
       "name": "pnp-copilot-pro-dev-da-teacher",
       "source": "pnp",
-      "title": "Career Coach Declarative Agent for Microsoft 365 Copilot Sample",
-      "shortDescription": "First Party Declarative Agent Career Coach shared as a sample",
-      "url": "https://github.com/pnp/copilot-pro-dev-samples/tree/main/samples/da-teacherr",
+      "title": "Declarative Agent The Simple Teacher for Microsoft 365 Copilot Sample",
+      "shortDescription": "The declarative agent The Simple Teacher acts as a friendly, patient, and humorous mentor for students aged 16 to 20, explaining technical concepts in simple, relatable language.",
+      "url": "https://github.com/pnp/copilot-pro-dev-samples/tree/main/samples/da-teacher",
       "downloadUrl": "https://pnp.github.io/download-partial/?url=https://github.com/pnp/copilot-pro-dev-samples/tree/main/samples/da-teacher",
       "longDescription": [
-        "The \"Career Coach\" Declarative Agent is an open-source AI-driven tool designed to assist professionals in their career development. This agent provides personalized suggestions and actionable plans to help users learn and grow in their careers. By leveraging data such as the user's current role, skills, and career aspirations, the Career Coach offers tailored advice on skill development, learning opportunities, and career transitions. It maintains a professional and supportive tone, ensuring that interactions are contextual and relevant. The agent integrates with OneDrive, SharePoint, and Graph Connectors to enhance its capabilities. Key features include creating detailed career development plans, performing skill gap analyses, recommending learning resources, and offering networking strategies. This open-source project aims to empower individuals to achieve their career goals through structured guidance and support. With the declarative agent, you can build a custom version of Copilot that can be used for specific scenarios, such as for specialized knowledge, implementing specific processes, or simply to save time by reusing a set of AI prompts. For example, a grocery shopping Copilot declarative agent can be used to create a grocery list based on a meal plan that you send to Copilot. To run this app template in your local dev machine, you will need Node.js (supported versions: 16, 18), a Microsoft 365 account for development, Teams Toolkit Visual Studio Code Extension version 5.0.0 and higher or Teams Toolkit CLI, and a Microsoft 365 Copilot license. First, select the Teams Toolkit icon on the left in the VS Code toolbar. In the Account section, sign in with your Microsoft 365 account if you haven't already. Create Teams app by clicking `Provision` in \"Lifecycle\" section. Select `Preview in Copilot (Edge)` or `Preview"    
+        "The declarative agent \"The Simple Teacher\" acts as a friendly, patient, and humorous mentor for students aged 16 to 20, explaining technical concepts in simple, relatable language. The agent always uses real-world analogies—especially from movies, pop culture, or daily life—and follows a clear structure: introducing the topic, providing a hook or analogy, explaining step by step, sharing a story or example, posing a student challenge, and summarizing the main points. The tone is casual and respectful, avoiding jargon unless explained, and never uses dry, academic, or negative language. The goal is to make learning engaging, memorable, and easy to understand."    
     ],
       "creationDateTime": "2025-05-10",
-      "updateDateTime": "2025-05-10",
+      "updateDateTime": "2025-05-15",
       "products": [
         "Microsoft 365 Copilot", "Teams Toolkit"
       ],


### PR DESCRIPTION
Fixing da-teacher sample.json

Typo in Github URL
Wrong:
Title
ShortDescription
LongDescription

sorry, I have not changed it