### PR TITLE
chore: update Dev Proxy samples to schema v3.0.1

### DIFF
--- a/samples/da-ristorante-api-devproxy-apikey/.devproxy/devproxyrc.json
+++ b/samples/da-ristorante-api-devproxy-apikey/.devproxy/devproxyrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.0/rc.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/rc.schema.json",
   "plugins": [
     {
       "name": "CrudApiPlugin",
@@ -18,11 +18,11 @@
     "http://api.ristorante.com/*"
   ],
   "dishesApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "dishes-api.json"
   },
   "ordersApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "orders-api.json"
   }
 }

--- a/samples/da-ristorante-api-devproxy-apikey/.devproxy/dishes-api.json
+++ b/samples/da-ristorante-api-devproxy-apikey/.devproxy/dishes-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/dishes",
   "dataFile": "dishes-data.json",
   "auth": "apiKey",

--- a/samples/da-ristorante-api-devproxy-apikey/.devproxy/orders-api.json
+++ b/samples/da-ristorante-api-devproxy-apikey/.devproxy/orders-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/orders",
   "dataFile": "orders-data.json",
   "auth": "apiKey",

--- a/samples/da-ristorante-api-devproxy-apikey/README.md
+++ b/samples/da-ristorante-api-devproxy-apikey/README.md
@@ -46,19 +46,18 @@ This sample illustrates the following concepts:
 
 Version|Date|Comments
 -------|----|--------
+1.1|June 16, 2026|Updated Dev Proxy schemas to v3.0.1
 1.0|May 14, 2026|Initial release
 
 ## Prerequisites
 
 * Microsoft 365 tenant with Microsoft 365 Copilot
-* [Dev Proxy](https://learn.microsoft.com/microsoft-cloud/dev/dev-proxy/overview) v3.0.0-beta.2 or later
+* [Dev Proxy](https://learn.microsoft.com/microsoft-cloud/dev/dev-proxy/overview) v3.0.1 or later
 * [Node.js](https://nodejs.org/)
 * [Visual Studio Code](https://code.visualstudio.com/) with the following extensions:
   * [Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
-  * [Dev Proxy Toolkit](https://marketplace.visualstudio.com/items?itemName=garrytrinder.dev-proxy-toolkit) v1.27.2 or later (pre-release)
+  * [Dev Proxy Toolkit](https://marketplace.visualstudio.com/items?itemName=garrytrinder.dev-proxy-toolkit)
   * [Dev Tunnels](https://marketplace.visualstudio.com/items?itemName=ms-devtunnels.ms-devtunnels)
-
-> **Note:** API key authentication support in the CrudApiPlugin requires Dev Proxy v3.0.0-beta.2 or later. You can use the **Dev Proxy: Switch Version** command in the Dev Proxy Toolkit extension to download and switch to the latest v3.0.0 beta.
 
 ## Minimal path to awesome
 

--- a/samples/da-ristorante-api-devproxy-apikey/assets/sample.json
+++ b/samples/da-ristorante-api-devproxy-apikey/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to build a declarative agent for Microsoft 365 Copilot that allows you to browse a menu of a local Italian restaurant and place an order. The agent uses an API plugin to connect to an API secured with an API key. Dev Proxy is used to simulate the API."
     ],
     "creationDateTime": "2026-05-14",
-    "updateDateTime": "2026-05-14",
+    "updateDateTime": "2026-06-16",
     "products": [
       "Microsoft 365 Copilot"
     ],

--- a/samples/da-ristorante-api-devproxy-entra/.devproxy/devproxyrc.json
+++ b/samples/da-ristorante-api-devproxy-entra/.devproxy/devproxyrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/rc.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/rc.schema.json",
   "plugins": [
     {
       "name": "CrudApiPlugin",
@@ -18,11 +18,11 @@
     "http://api.ristorante.com/*"
   ],
   "dishesApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "dishes-api.json"
   },
   "ordersApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "orders-api.json"
   }
 }

--- a/samples/da-ristorante-api-devproxy-entra/.devproxy/dishes-api.json
+++ b/samples/da-ristorante-api-devproxy-entra/.devproxy/dishes-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/dishes",
   "dataFile": "dishes-data.json",
   "auth": "entra",

--- a/samples/da-ristorante-api-devproxy-entra/.devproxy/orders-api.json
+++ b/samples/da-ristorante-api-devproxy-entra/.devproxy/orders-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/orders",
   "dataFile": "orders-data.json",
   "auth": "entra",

--- a/samples/da-ristorante-api-devproxy-entra/README.md
+++ b/samples/da-ristorante-api-devproxy-entra/README.md
@@ -51,6 +51,7 @@ This sample illustrates the following concepts:
 
 Version|Date|Comments
 -------|----|--------
+1.1|June 16, 2026|Updated Dev Proxy schemas to v3.0.1
 1.0|May 14, 2026|Initial release
 
 ## Prerequisites

--- a/samples/da-ristorante-api-devproxy-entra/assets/sample.json
+++ b/samples/da-ristorante-api-devproxy-entra/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to build a declarative agent for Microsoft 365 Copilot that allows you to browse a menu of a local Italian restaurant and place an order. The agent uses an API plugin to connect to an API secured with OAuth (Microsoft Entra). Dev Proxy is used to simulate the API."
     ],
     "creationDateTime": "2026-05-14",
-    "updateDateTime": "2026-05-14",
+    "updateDateTime": "2026-06-16",
     "products": [
       "Microsoft 365 Copilot"
     ],

--- a/samples/da-ristorante-api-devproxy/.devproxy/devproxyrc.json
+++ b/samples/da-ristorante-api-devproxy/.devproxy/devproxyrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/rc.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/rc.schema.json",
   "plugins": [
     {
       "name": "CrudApiPlugin",
@@ -18,11 +18,11 @@
     "http://api.ristorante.com/*"
   ],
   "dishesApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "dishes-api.json"
   },
   "ordersApi": {
-    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.schema.json",
+    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.schema.json",
     "apiFile": "orders-api.json"
   }
 }

--- a/samples/da-ristorante-api-devproxy/.devproxy/dishes-api.json
+++ b/samples/da-ristorante-api-devproxy/.devproxy/dishes-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/dishes",
   "dataFile": "dishes-data.json",
   "auth": "none",

--- a/samples/da-ristorante-api-devproxy/.devproxy/orders-api.json
+++ b/samples/da-ristorante-api-devproxy/.devproxy/orders-api.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.4.0/crudapiplugin.apifile.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.0.1/crudapiplugin.apifile.schema.json",
   "baseUrl": "http://api.ristorante.com/orders",
   "dataFile": "orders-data.json",
   "auth": "none",

--- a/samples/da-ristorante-api-devproxy/README.md
+++ b/samples/da-ristorante-api-devproxy/README.md
@@ -42,6 +42,7 @@ This sample illustrates the following concepts:
 
 Version|Date|Comments
 -------|----|--------
+1.1|June 16, 2026|Updated Dev Proxy schemas to v3.0.1
 1.0|May 14, 2026|Initial release
 
 ## Prerequisites

--- a/samples/da-ristorante-api-devproxy/assets/sample.json
+++ b/samples/da-ristorante-api-devproxy/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to build a declarative agent for Microsoft 365 Copilot that allows you to browse a menu of a local Italian restaurant and place an order. The agent uses an API plugin to connect to an anonymous API. Dev Proxy is used to simulate the API."
     ],
     "creationDateTime": "2026-05-14",
-    "updateDateTime": "2026-05-14",
+    "updateDateTime": "2026-06-16",
     "products": [
       "Microsoft 365 Copilot"
     ],


### PR DESCRIPTION
## Summary

Updates all 3 Dev Proxy ristorante samples to use Dev Proxy schema v3.0.1.

## Changes

### All samples
- Updated Dev Proxy `$schema` references to `v3.0.1` across `devproxyrc.json`, `dishes-api.json`, and `orders-api.json`
- Added version 1.1 entry to README version history
- Updated `updateDateTime` in `sample.json` to `2026-06-16`

### da-ristorante-api-devproxy
- Schema updated from `v2.4.0` → `v3.0.1`

### da-ristorante-api-devproxy-apikey
- Schema updated from `v3.0.0` → `v3.0.1`
- Updated Dev Proxy prerequisite from `v3.0.0-beta.2` → `v3.0.1`
- Removed pre-release version note from Dev Proxy Toolkit extension prerequisite
- Removed beta note about CrudApiPlugin API key support

### da-ristorante-api-devproxy-entra
- Schema updated from `v2.4.0` → `v3.0.1`
- Removed `validDomains` from `manifest.json`
- Restored `<ENTRA_APP_CLIENT_ID>` and `<ENTRA_APP_TENANT_ID>` placeholders in API files