### PR TITLE
fix: update devproxy token command in .http files

### DIFF
--- a/samples/da-ristorante-api-devproxy-entra-sso/api.http
+++ b/samples/da-ristorante-api-devproxy-entra-sso/api.http
@@ -1,6 +1,6 @@
 @baseUrl = {{$dotenv OPENAPI_SERVER_URL}}
 # Generate a test token using the Dev Proxy CLI:
-# devproxy token new --name "Dev Proxy" --audience {ENTRA_APP_CLIENT_ID} --issuer https://login.microsoftonline.com/{ENTRA_APP_TENANT_ID}/v2.0 --scopes "api://{ENTRA_APP_CLIENT_ID}/Dishes.Read api://{ENTRA_APP_CLIENT_ID}/Orders.Write"
+# devproxy jwt create -n "Dev Proxy" -a {ENTRA_APP_CLIENT_ID} -i https://login.microsoftonline.com/{ENTRA_APP_TENANT_ID}/v2.0 -s "api://{ENTRA_APP_CLIENT_ID}/Dishes.Read" -s "api://{ENTRA_APP_CLIENT_ID}/Orders.Write"
 # Replace {ENTRA_APP_CLIENT_ID} and {ENTRA_APP_TENANT_ID} with values from env/.env.local
 @token = <your-entra-access-token>
 

--- a/samples/da-ristorante-api-devproxy-oauth/api.http
+++ b/samples/da-ristorante-api-devproxy-oauth/api.http
@@ -1,6 +1,6 @@
 @baseUrl = {{$dotenv OPENAPI_SERVER_URL}}
 # Generate a test token using the Dev Proxy CLI:
-# devproxy token new --name "Dev Proxy" --audience {ENTRA_APP_CLIENT_ID} --issuer https://login.microsoftonline.com/{ENTRA_APP_TENANT_ID}/v2.0 --scopes "api://{ENTRA_APP_CLIENT_ID}/Dishes.Read api://{ENTRA_APP_CLIENT_ID}/Orders.Write"
+# devproxy jwt create -n "Dev Proxy" -a {ENTRA_APP_CLIENT_ID} -i https://login.microsoftonline.com/{ENTRA_APP_TENANT_ID}/v2.0 -s "api://{ENTRA_APP_CLIENT_ID}/Dishes.Read" -s "api://{ENTRA_APP_CLIENT_ID}/Orders.Write"
 # Replace {ENTRA_APP_CLIENT_ID} and {ENTRA_APP_TENANT_ID} with values from env/.env.local
 @token = <your-entra-access-token>
 


### PR DESCRIPTION
Replace deprecated `devproxy token new` with `devproxy jwt create` syntax in the oauth and entra-sso sample `.http` files.

## Changes

- `samples/da-ristorante-api-devproxy-entra-sso/api.http` — updated token creation comment
- `samples/da-ristorante-api-devproxy-oauth/api.http` — updated token creation comment